### PR TITLE
patched Makefile to honor predefined standard variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-PREFIXDIR = /usr/local
-BINDIR = /bin
-MANDIR = /usr/share/man/man8
+prefix ?= /usr/local
+bindir ?= /bin
+mandir ?= /usr/share/man/man8
 PROG = numatop
-CC = gcc
-LD = gcc
-CFLAGS = -g -Wall -O2
+CC ?= gcc
+LD ?= gcc
+CFLAGS ?= -g -Wall -O2
 LDLIBS = -lncurses -lpthread -lnuma
 
 COMMON_OBJS = cmd.o disp.o lwp.o node.o numatop.o page.o perf.o \
@@ -16,7 +16,7 @@ INTEL_OBJS = wsm.o snb.o nhm.o
 all: $(PROG)
 
 $(PROG): $(COMMON_OBJS) $(INTEL_OBJS)
-	$(LD) $(LDLIBS) -o $@ $(COMMON_OBJS) $(INTEL_OBJS)
+	$(LD) $(LDFLAGS) -o $@ $(COMMON_OBJS) $(INTEL_OBJS) $(LDLIBS)
 
 %.o: ./common/%.c ./common/include/*.h
 	$(CC) $(CFLAGS) -o $@ -c $<
@@ -25,9 +25,9 @@ $(PROG): $(COMMON_OBJS) $(INTEL_OBJS)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 install: $(PROG)
-	install -m 0755 $(PROG) $(PREFIXDIR)$(BINDIR)/
+	install -D -m 0755 $(PROG) $(DESTDIR)$(prefix)$(bindir)/$(PROG)
 	gzip -c numatop.8 > numatop.8.gz
-	mv -f numatop.8.gz $(MANDIR)/
+	install -D numatop.8.gz $(DESTDIR)$(mandir)/numatop.8.gz
 
 clean:
 	rm -rf *.o $(PROG)


### PR DESCRIPTION
Please apply the attached commit to patch Makefile. Afterwards, it uses standard variable names as explained in the following documents:

http://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables
http://www.gnu.org/prep/standards/html_node/DESTDIR.html#DESTDIR

and only sets the variables to the value in the Makefile, if they are not previously set. Additionally, the install commands will create the necessary directories if they do not exist.

The changes enable Gentoo Linux users to set their own flags as everyone compiles their applications from source here (fyi, in this case with https://github.com/anyc/anyc-overlay/blob/master/sys-process/numatop/numatop-1.0.ebuild). Thank you!
