### PR TITLE
patched Makefile to honor predefined standard variables (II)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-PREFIXDIR = /usr/local
-BINDIR = /bin
-MANDIR = /usr/share/man/man8
+prefix ?= /usr/local
+bindir ?= /bin
+mandir ?= /usr/share/man/man8
 PROG = numatop
-CC = gcc
-LD = gcc
-CFLAGS = -g -Wall -O2
+CC ?= gcc
+CFLAGS ?= -g -Wall -O2
 LDLIBS = -lncurses -lpthread -lnuma
 
 COMMON_OBJS = cmd.o disp.o lwp.o node.o numatop.o page.o perf.o \
@@ -16,7 +15,7 @@ INTEL_OBJS = wsm.o snb.o nhm.o
 all: $(PROG)
 
 $(PROG): $(COMMON_OBJS) $(INTEL_OBJS)
-	$(LD) $(LDLIBS) -o $@ $(COMMON_OBJS) $(INTEL_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(COMMON_OBJS) $(INTEL_OBJS) $(LDLIBS)
 
 %.o: ./common/%.c ./common/include/*.h
 	$(CC) $(CFLAGS) -o $@ -c $<
@@ -25,9 +24,9 @@ $(PROG): $(COMMON_OBJS) $(INTEL_OBJS)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 install: $(PROG)
-	install -m 0755 $(PROG) $(PREFIXDIR)$(BINDIR)/
+	install -D -m 0755 $(PROG) $(DESTDIR)$(prefix)$(bindir)/$(PROG)
 	gzip -c numatop.8 > numatop.8.gz
-	mv -f numatop.8.gz $(MANDIR)/
+	install -D numatop.8.gz $(DESTDIR)$(mandir)/numatop.8.gz
 
 clean:
 	rm -rf *.o $(PROG)


### PR DESCRIPTION
Sorry, I missed the issue from pull request #1. Actually, the way the linking command is written, it's not meant to call the linker directly (in http://www.lisha.ufsc.br/teaching/os/exercise/hello.html there's an example how ld is called directly). Therefore I would recommend to also call CC instead of LD in this case. Setting LD to $(CC) would also do but I think it would be misleading as we want to call the compiler not the linker. Thank you!
