### PR TITLE
Fix the i686 build with hardening

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -319,6 +319,7 @@ static void
 cpuid(unsigned int *eax, unsigned int *ebx, unsigned int *ecx,
 	unsigned int *edx)
 {
+#if __x86_64
 	__asm volatile(
 	    "cpuid\n\t"
 	    :"=a" (*eax),
@@ -326,6 +327,19 @@ cpuid(unsigned int *eax, unsigned int *ebx, unsigned int *ecx,
 	    "=c" (*ecx),
 	    "=d" (*edx)
 	    :"a" (*eax));
+#else
+	__asm volatile(
+	    "push %%ebx\n\t"
+	    "cpuid\n\t"
+	    "mov %%ebx, (%4)\n\t"
+	    "pop %%ebx"
+	    :"=a" (*eax),
+	    "=c" (*ecx),
+	    "=d" (*edx)
+	    :"0" (*eax),
+	    "S" (ebx)
+	    :"memory");
+#endif
 }
 
 /*


### PR DESCRIPTION
This is a follow-up of issues #3 and #4 that solve several problems for hardened builds, but not the cpuid part.

The __cpuid fix doesn't solve the __asm issue, and @keszybz accidentally tested a numactl build. This pull request reverts all the changes made for the issue #3 and fixes the i686 hardened build:
http://koji.fedoraproject.org/koji/taskinfo?taskID=5934627

I have tested the output of cpuid on the (limited) hardware I own, and it's the same with or without this patch.
