### PR TITLE
configure.ac: add build support for 32 bit i686 architectures

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,10 +10,8 @@ LT_INIT
 AC_CONFIG_MACRO_DIRS([m4])
 
 AC_CANONICAL_HOST
-AM_CONDITIONAL(CPU_INTEL, test "x$host_cpu" = "xx86_64")
-AM_CONDITIONAL(CPU_INTEL, test "x$host_cpu" = "xi686")
-AM_CONDITIONAL(CPU_PPC, test "x$host_cpu" = "xpowerpc64")
-AM_CONDITIONAL(CPU_PPC, test "x$host_cpu" = "xpowerpc64le")
+AM_CONDITIONAL(CPU_INTEL, test "x$host_cpu" = "xx86_64" -o "x$host_cpu" = "xi686")
+AM_CONDITIONAL(CPU_PPC, test "x$host_cpu" = "xpowerpc64" -o "x$host_cpu" = "xpowerpc64le")
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
Correctly Set CPU_INTEL for i686 as well as for x86-64 CPUs. Use
same logic for powerpc variants for CPU_PPC

Signed-off-by: Colin Ian King <colin.king@canonical.com>