### PR TITLE
common/os: ensure command buffer is large enough (fix gcc warnings)

### DIFF
--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -766,7 +766,7 @@ void os_cmt_fini(void)
 
 int os_sysfs_cmt_task_set(int pid, int lwpid, struct _perf_pqos *pqos)
 {
-	char command[128], path[128];
+	char command[160], path[128];
 
 	if (lwpid)
 		pqos->task_id = lwpid;


### PR DESCRIPTION
Make command buffer large enough, fixes gcc 8.2 warnings:

common/os/os_util.c: In function ‘os_sysfs_cmt_task_set’:
common/os/os_util.c:781:45: warning: ‘%s’ directive output
may be truncated writing up to 127 bytes into a region of
size 121 [-Wformat-truncation=]
  snprintf(command, sizeof(command), "rm -rf %s 2>/dev/null", path);
                                             ^~               ~~~~

common/os/os_util.c:785:44: warning: ‘%s’ directive output
may be truncated writing up to 127 bytes into a region of
size 122 [-Wformat-truncation=]
  snprintf(command, sizeof(command), "mkdir %s 2>/dev/null", path);
                                            ^~               ~~~~

common/os/os_util.c:794:15: warning: ‘%s’ directive output
may be truncated writing up to 127 bytes into a region of
size between 109 and 119 [-Wformat-truncation=]

    "echo %d > %s/tasks", lwpid, path);
               ^~                ~~~~

common/os/os_util.c:791:15: warning: ‘%s’ directive output
may be truncated writing up to 127 bytes into a region of
size between 109 and 119 [-Wformat-truncation=]

    "echo %d > %s/tasks", pid, path);
               ^~              ~~~~
In file included from /usr/include/stdio.h:862,
                 from common/os/os_util.c:33:

Signed-off-by: Colin Ian King <colin.king@canonical.com>