### PR TITLE
Trivial fix to spelling mistakes in source

### DIFF
--- a/common/include/os/linux/perf_event.h
+++ b/common/include/os/linux/perf_event.h
@@ -526,7 +526,7 @@ struct perf_event_mmap_page {
 	 * after reading this value.
 	 *
 	 * When the mapping is PROT_WRITE the @data_tail value should be
-	 * written by userspace to reflect the last read data, after issueing
+	 * written by userspace to reflect the last read data, after issuing
 	 * an smp_mb() to separate the data read from the ->data_tail store.
 	 * In this case the kernel will not over-write unread data.
 	 *

--- a/common/win.c
+++ b/common/win.c
@@ -315,7 +315,7 @@ topnproc_win_destroy(dyn_win_t *win)
 }
 
 /*
- * Seperate the value of metrics by raw perf data.
+ * Separate the value of metrics by raw perf data.
  */
 static int
 win_countvalue_fill(win_countvalue_t *cv,
@@ -2163,7 +2163,7 @@ lat_win_destroy(dyn_win_t *win)
 
 /*
  * Due to the limitation of screen size, the string of path
- * probablly needs to be cut. For example:
+ * probably needs to be cut. For example:
  * /export/home/jinyao/ws/numatop-gate/usr/src/cmd/numatop/amd64/numatop
  * probably is cut to:
  * ../usr/src/cmd/numatop/amd64/numatop


### PR DESCRIPTION
Nothing major, just a few spelling mistake fixes

Signed-off-by: Colin Ian King <colin.king@canonical.com>