### PR TITLE
common/reg.c: use explicit format string

### DIFF
--- a/common/reg.c
+++ b/common/reg.c
@@ -240,7 +240,7 @@ reg_line_write(win_reg_t *r, int line, reg_align_t align, char *content)
 	}
 
 	if (len > 0) {
-		(void) mvwprintw(r->hdl, line, pos_x, content);
+		(void) mvwprintw(r->hdl, line, pos_x, "%s", content);
 	}
 
 	if (r->mode != 0) {
@@ -267,7 +267,7 @@ reg_highlight_write(win_reg_t *r, int line, int align, char *content)
 	}
 
 	if (len > 0) {
-		(void) mvwprintw(r->hdl, line, pos_x, content);
+		(void) mvwprintw(r->hdl, line, pos_x, "%s", content);
 	}
 
 	(void) wattroff(r->hdl, A_REVERSE | A_BOLD);


### PR DESCRIPTION
Fixes compilation errors such as:

```
common/reg.c: In function 'reg_line_write':
common/reg.c:243:3: error: format not a string literal and no format arguments [https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security]
  243 |   (void) mvwprintw(r->hdl, line, pos_x, content);
      |   ^
common/reg.c: In function 'reg_highlight_write':
common/reg.c:270:3: error: format not a string literal and no format arguments [https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security]
  270 |   (void) mvwprintw(r->hdl, line, pos_x, content);
      |   ^
```

It's common for distributions to enable format string checking,
so resolving this is likely useful for others as well.