### PR TITLE
numatop/powerpc: Add power10 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,10 +83,12 @@ if CPU_PPC
 libnumatop_la_SOURCES += \
 	powerpc/include/power8.h \
 	powerpc/include/power9.h \
+	powerpc/include/power10.h \
 	powerpc/include/types.h \
 	powerpc/plat.c \
 	powerpc/power8.c \
 	powerpc/power9.c \
+	powerpc/power10.c \
 	powerpc/ui_perf_map.c \
 	powerpc/util.c
 endif

--- a/numatop.8
+++ b/numatop.8
@@ -500,4 +500,4 @@ in 3.9. The following steps show how to get and apply the patch set.
 \fBnumatop\fP supports the Intel Xeon processors: 5500-series, 6500/7500-series, 
 5600 series, E7-x8xx-series, and E5-16xx/24xx/26xx/46xx-series. 
 \fBNote\fP: CPU microcode version 0x618 or 0x70c or later is required on
-E5-16xx/24xx/26xx/46xx-series. It also supports IBM Power8 and Power9 processors.
+E5-16xx/24xx/26xx/46xx-series. It also supports IBM Power8, Power9 and Power10 processors.

--- a/powerpc/include/power10.h
+++ b/powerpc/include/power10.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, IBM Corporation
+ * Copyright (c) 2023, IBM Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -26,32 +26,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#ifndef _NUMATOP_POWERPC_POWER10_H
+#define _NUMATOP_POWERPC_POWER10_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <inttypes.h>
 #include "../../common/include/types.h"
 
-#define CORP "IBM"
+struct _plat_event_config;
 
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8,
-	CPU_POWER9,
-	CPU_POWER10
-} cpu_type_t;
+extern void power10_profiling_config(perf_count_id_t, struct _plat_event_config *);
+extern void power10_ll_config(plat_event_config_t *cfg);
+extern int power10_offcore_num(void);
 
-#define CPU_TYPE_NUM    4
+#ifdef __cplusplus
+}
+#endif
 
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
-
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+#endif /* _NUMATOP_POWERPC_POWER10_H */

--- a/powerpc/plat.c
+++ b/powerpc/plat.c
@@ -35,26 +35,30 @@
 #include "include/types.h"
 #include "include/power8.h"
 #include "include/power9.h"
+#include "include/power10.h"
 
 pfn_plat_profiling_config_t
 s_plat_profiling_config[CPU_TYPE_NUM] = {
 	NULL,
 	power8_profiling_config,
-	power9_profiling_config
+	power9_profiling_config,
+	power10_profiling_config
 };
 
 pfn_plat_ll_config_t
 s_plat_ll_config[CPU_TYPE_NUM] = {
 	NULL,
 	power8_ll_config,
-	power9_ll_config
+	power9_ll_config,
+	power10_ll_config
 };
 
 pfn_plat_offcore_num_t
 s_plat_offcore_num[CPU_TYPE_NUM] = {
 	NULL,
 	power8_offcore_num,
-	power9_offcore_num
+	power9_offcore_num,
+	power10_offcore_num
 };
 
 #define SPRN_PVR	0x11F
@@ -83,6 +87,10 @@ plat_detect(void)
 			break;
 
 		s_cpu_type = CPU_POWER9;
+		ret = 0;
+		break;
+	case 0x80:
+		s_cpu_type = CPU_POWER10;
 		ret = 0;
 		break;
 	}

--- a/powerpc/power10.c
+++ b/powerpc/power10.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, IBM Corporation
+ * Copyright (c) 2023, IBM Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -26,32 +26,44 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NUMATOP_POWERPC_TYPES_H
-#define _NUMATOP_POWERPC_TYPES_H
+#include <inttypes.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <strings.h>
+#include "../common/include/os/linux/perf_event.h"
+#include "../common/include/os/plat.h"
+#include "include/power10.h"
 
-#include "../../common/include/types.h"
+static plat_event_config_t s_power10_profiling[PERF_COUNT_NUM] = {
+	{ PERF_TYPE_RAW, 0x600f4, 0, 0, 0, 0, "PM_RUN_CYC" },
+	{ PERF_TYPE_RAW, 0x0F4040000004C040, 0, 0, 0, 0, "PM_DATA_FROM_DMEM" },
+	{ PERF_TYPE_RAW, 0x100f0, 0, 0, 0, 0, "PM_CYC" },
+	{ PERF_TYPE_RAW, 0x500fa, 0, 0, 0, 0, "PM_RUN_INST_CMPL" },
+	{ PERF_TYPE_RAW, 0x094040000002C040, 0, 0, 0, 0, "PM_DATA_FROM_LMEM" },
+	{ PERF_TYPE_RAW, 0x0D4040000003C040, 0, 0, 0, 0, "PM_DATA_FROM_RMEM" },
+};
 
-#define CORP "IBM"
+static plat_event_config_t s_power10_ll = {
+	PERF_TYPE_RAW, 0x0000, 0, 0, 0, 1, "PM_SUSPENDED"
+};
 
-typedef enum {
-	CPU_UNSUP = 0,
-	CPU_POWER8,
-	CPU_POWER9,
-	CPU_POWER10
-} cpu_type_t;
+void
+power10_profiling_config(perf_count_id_t perf_count_id, plat_event_config_t *cfg)
+{
+	plat_config_get(perf_count_id, cfg, s_power10_profiling);
+}
 
-#define CPU_TYPE_NUM    4
+void
+power10_ll_config(plat_event_config_t *cfg)
+{
+	memcpy(cfg, &s_power10_ll, sizeof (plat_event_config_t));
+}
 
-typedef enum {
-	PERF_COUNT_INVALID = -1,
-	PERF_COUNT_CORE_CLK = 0,
-	PERF_COUNT_RMA,
-	PERF_COUNT_CLK,
-	PERF_COUNT_IR,
-	PERF_COUNT_LMA,
-	PERF_COUNT_RMA_1
-} perf_count_id_t;
-
-#define PERF_COUNT_NUM	6
-
-#endif /* _NUMATOP_POWERPC_TYPES_H */
+int
+power10_offcore_num(void)
+{
+	return (3);
+}


### PR DESCRIPTION
Add platform check for power10 processors.
Add new files called power10.c/power10.h, which includes addition of the relevant events, to count per-process/per-thread memory accesses and CPU usage information for power10 processors.