### PR TITLE
Squash default GCC warnings on Fedora 39

### DIFF
--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -387,12 +387,10 @@ str_int_extract(char *str, int *arr, int arr_size, int *num)
 	int len = strlen(str);
 	boolean_t ret = B_FALSE;
 
-	if ((scopy = malloc(len + 1)) == NULL) {
+	if ((scopy = strdup(str)) == NULL) {
 		return (B_FALSE);
 	}
 
-	strncpy(scopy, str, len);
-	scopy[len] = 0;
 	cur = scopy;
 
 	while (cur < (scopy + len)) {

--- a/common/os/os_win.c
+++ b/common/os/os_win.c
@@ -29,6 +29,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
@@ -105,6 +106,28 @@ cpuid_cmp(const void *a, const void *b)
 	return (0);
 }
 
+static void
+print_buf(char **destp, int *sizep, const char *fmt, ...)
+{
+	va_list ap;
+	int len;
+
+	if (*sizep <= 0)
+		return;
+
+	va_start(ap, fmt);
+	len = vsnprintf(*destp, *sizep, fmt, ap);
+	va_end(ap);
+
+	if (len >= *sizep) {
+		*sizep = 0;
+		return;
+	}
+
+	*destp += len;
+	*sizep -= len;
+}
+
 /*
  * Build a readable string of CPU ID and try to reduce the string length. e.g.
  * For cpu1, cpu2, cpu3, cpu4, the string is "CPU(1-4)",
@@ -113,7 +136,6 @@ cpuid_cmp(const void *a, const void *b)
 static void
 node_cpu_string(node_t *node, char *s1, int size)
 {
-	char s2[128], s3[128];
 	int i, j, k, l, cpuid_start;
 	int *cpuid_arr;
 	int ncpus;
@@ -140,8 +162,7 @@ node_cpu_string(node_t *node, char *s1, int size)
 	cpuid_start = cpuid_arr[0];
 
 	if (ncpus == 1) {
-		(void) snprintf(s2, sizeof (s2), "%d", cpuid_start);
-        	(void) strncat(s1, s2, strlen(s2));
+		(void) snprintf(s1, size, "%d", cpuid_start);
         	free(cpuid_arr);
 		return;
 	}
@@ -154,33 +175,28 @@ node_cpu_string(node_t *node, char *s1, int size)
 		if (cpuid_arr[j] != cpuid_start + l) {
 			if (k < ncpus) {
 				if (l == 1) {
-					(void) snprintf(s2, sizeof (s2), "%d ", cpuid_start);
+					print_buf(&s1, &size, "%d ", cpuid_start);
 				} else {
-					(void) snprintf(s2, sizeof (s2),
+					print_buf(&s1, &size,
 						"%d-%d ", cpuid_start, cpuid_start + l - 1);
 				}
           		} else {
 				if (l == 1) {
-					(void) snprintf(s2, sizeof (s2), "%d",
-						cpuid_start);
+					print_buf(&s1, &size, "%d", cpuid_start);
 				} else {
-					(void) snprintf(s2, sizeof (s2), "%d-%d",
+					print_buf(&s1, &size, "%d-%d",
 						cpuid_start, cpuid_start + l - 1);
 				}
 
-				(void) snprintf(s3, sizeof (s3), " %d",
-					cpuid_arr[j]);
-	        	  	(void) strncat(s2, s3, strlen(s3));
+				print_buf(&s1, &size, " %d", cpuid_arr[j]);
 			}
 
-          		(void) strncat(s1, s2, strlen(s2));
           		cpuid_start = cpuid_arr[j];
            		l = 1;
 		} else {
 	        	if (k == ncpus) {
-        	    		(void) snprintf(s2, sizeof (s2), "%d-%d",
+				print_buf(&s1, &size, "%d-%d",
                 			cpuid_start, cpuid_start + l);
-         			(void) strncat(s1, s2, strlen(s2));
        			} else {
             			l++;
        			}

--- a/common/os/os_win.c
+++ b/common/os/os_win.c
@@ -222,7 +222,7 @@ nodedetail_line_show(win_reg_t *reg, char *title, char *value, int line)
 void
 os_nodedetail_data(dyn_nodedetail_t *dyn, win_reg_t *seg)
 {
-	char s1[256], s2[32];
+	char s1[512], s2[32];
 	node_t *node;
 	win_countvalue_t value;
 	node_meminfo_t meminfo;

--- a/common/os/sym.c
+++ b/common/os/sym.c
@@ -463,7 +463,7 @@ L_EXIT:
 }
 
 static int
-elf64_binary_read(sym_binary_t *binary, unsigned int sym_type)
+elf64_binary_read(sym_binary_t *binary, sym_type_t sym_type)
 {
 	Elf64_Ehdr ehdr;
 	Elf64_Shdr shdr;

--- a/common/reg.c
+++ b/common/reg.c
@@ -240,7 +240,7 @@ reg_line_write(win_reg_t *r, int line, reg_align_t align, char *content)
 	}
 
 	if (len > 0) {
-		(void) mvwprintw(r->hdl, line, pos_x, content);
+		(void) mvwprintw(r->hdl, line, pos_x, "%s", content);
 	}
 
 	if (r->mode != 0) {
@@ -267,7 +267,7 @@ reg_highlight_write(win_reg_t *r, int line, int align, char *content)
 	}
 
 	if (len > 0) {
-		(void) mvwprintw(r->hdl, line, pos_x, content);
+		(void) mvwprintw(r->hdl, line, pos_x, "%s", content);
 	}
 
 	(void) wattroff(r->hdl, A_REVERSE | A_BOLD);

--- a/common/win.c
+++ b/common/win.c
@@ -355,8 +355,7 @@ topnproc_data_save(track_proc_t *proc, int intval, topnproc_line_t *line)
 	/*
 	 * Cut off the process name if it's too long.
 	 */
-	(void) strncpy(line->proc_name, proc->name, sizeof (line->proc_name));
-	line->proc_name[WIN_PROCNAME_SIZE - 1] = 0;
+	memcpy(line->proc_name, proc->name, sizeof (line->proc_name) - 1);
 	line->pid = proc->pid;
 	line->nlwp = proc_nlwp(proc);
 
@@ -2892,8 +2891,7 @@ pqos_cmt_proc_data_save(track_proc_t *proc, track_lwp_t *lwp, int intval,
 {
 	(void) memset(line, 0, sizeof (pqos_cmt_proc_line_t));
 
-	(void) strncpy(line->proc_name, proc->name, sizeof (line->proc_name));
-	line->proc_name[WIN_PROCNAME_SIZE - 1] = 0;
+	memcpy(line->proc_name, proc->name, sizeof (line->proc_name) - 1);
 	line->pid = proc->pid;
 	line->nlwp = proc_nlwp(proc);
 
@@ -3216,8 +3214,7 @@ pqos_mbm_proc_data_save(track_proc_t *proc, track_lwp_t *lwp, int intval,
 {
 	(void) memset(line, 0, sizeof (pqos_mbm_proc_line_t));
 
-	(void) strncpy(line->proc_name, proc->name, sizeof (line->proc_name));
-	line->proc_name[WIN_PROCNAME_SIZE - 1] = 0;
+	memcpy(line->proc_name, proc->name, sizeof (line->proc_name) - 1);
 	line->pid = proc->pid;
 	line->nlwp = proc_nlwp(proc);
 

--- a/common/win.c
+++ b/common/win.c
@@ -484,14 +484,11 @@ topnproc_data_show(dyn_win_t *win)
 static void
 load_msg_show(void)
 {
-	char content[64];
 	win_reg_t r;
-
-	(void) snprintf(content, sizeof (content), "Loading ...");
 
 	(void) reg_init(&r, 0, 1, g_scr_width, g_scr_height - 1, A_BOLD);
 	reg_erase(&r);
-	reg_line_write(&r, 1, ALIGN_LEFT, content);
+	reg_line_write(&r, 1, ALIGN_LEFT, "Loading ...");
 	reg_refresh(&r);
 	reg_win_destroy(&r);
 }

--- a/x86/skl.c
+++ b/x86/skl.c
@@ -64,11 +64,11 @@ static plat_event_config_t s_spr_config[PERF_COUNT_NUM] = {
 };
 
 static plat_event_config_t s_emr_config[PERF_COUNT_NUM] = {
-	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.core" },
-	{ PERF_TYPE_RAW, 0x012A, 0x53, 0x730000001, "off_core_response_0" },
-	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, "cpu_clk_unhalted.ref" },
-	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS, 0x53, 0, "instr_retired.any" },
-	{ PERF_TYPE_RAW, 0x012B, 0x53, 0x104000001, "off_core_response_1" }
+	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_CPU_CYCLES, 0x53, 0, 0, 0, "cpu_clk_unhalted.core" },
+	{ PERF_TYPE_RAW, 0x012A, 0x53, 0x730000001, 0, 0, "off_core_response_0" },
+	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_REF_CPU_CYCLES, 0x53, 0, 0, 0, "cpu_clk_unhalted.ref" },
+	{ PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS, 0x53, 0, 0, 0, "instr_retired.any" },
+	{ PERF_TYPE_RAW, 0x012B, 0x53, 0x104000001, 0, 0, "off_core_response_1" }
 };
 
 static plat_event_config_t s_skl_ll = {


### PR DESCRIPTION
There are two more when building with Clang, but this first batch is already a handful.