### PR TITLE
numatop/powerpc: Add Power11 support

### DIFF
--- a/numatop.8
+++ b/numatop.8
@@ -500,4 +500,4 @@ in 3.9. The following steps show how to get and apply the patch set.
 \fBnumatop\fP supports the Intel Xeon processors: 5500-series, 6500/7500-series, 
 5600 series, E7-x8xx-series, and E5-16xx/24xx/26xx/46xx-series. 
 \fBNote\fP: CPU microcode version 0x618 or 0x70c or later is required on
-E5-16xx/24xx/26xx/46xx-series. It also supports IBM Power8, Power9 and Power10 processors.
+E5-16xx/24xx/26xx/46xx-series. It also supports IBM Power8, Power9, Power10 and Power11 processors.

--- a/powerpc/plat.c
+++ b/powerpc/plat.c
@@ -93,6 +93,11 @@ plat_detect(void)
 		s_cpu_type = CPU_POWER10;
 		ret = 0;
 		break;
+
+	case 0x82:
+		s_cpu_type = CPU_POWER10;
+		ret = 0;
+		break;
 	}
 
 	return ret;


### PR DESCRIPTION
Power11 is PowerISA v3.1 compliant processor and support Power10 events. Hence, using Power10 events to enable numatop in Power11 platform and to count the per-process/per-thread memory accesses and CPU usage.