### PR TITLE
x86: Add support for Zen 5 processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ numatop is supported on Intel Xeon processors: 5500-series, 6500/7500-series,
 E5-16xx/24xx/26xx/46xx-series had better be updated to latest CPU microcode
 (microcode must be 0x618+ or 0x70c+).
 
+AMD EPYC processors from the 7001, 7002, 7003, 4004, 8004 and 9004 series are
+also supported.
+
 To learn about NumaTOP, please visit http://01.org/numatop
 
 

--- a/x86/plat.c
+++ b/x86/plat.c
@@ -210,6 +210,8 @@ cpu_type_get(void)
 		} else {
 			type = CPU_ZEN4;
 		}
+	} else if (family >= 26) {	/* Family 1Ah and later */
+		type = CPU_ZEN4;
 	}
 
 	return (type);


### PR DESCRIPTION
Zen 5 can reuse features from the Zen 4 CPU model without requiring significant changes.
