### PR TITLE
common: perform sanity check on num to avoid array bounds underflow/o…

### DIFF
--- a/common/os/node.c
+++ b/common/os/node.c
@@ -167,6 +167,9 @@ cpu_refresh(boolean_t init)
 			if (!os_sysfs_cpu_enum(node->nid, cpu_arr, NCPUS_NODE_MAX, &num)) {
 				return (-1);
 			}
+			if (num < 0 || num >= NCPUS_NODE_MAX) {
+				return (-1);
+			}
 
 			if (os_perf_cpuarr_refresh(node->cpus, NCPUS_NODE_MAX, cpu_arr,
 				num, init) != 0) {
@@ -223,6 +226,9 @@ node_group_refresh(boolean_t init)
 
 	node_group_lock();
 	if (!os_sysfs_node_enum(node_arr, NNODES_MAX, &num)) {
+		goto L_EXIT;
+	}
+	if (num < 0 || num >= NNODES_MAX) {
 		goto L_EXIT;
 	}
 


### PR DESCRIPTION
…verflow

The integer num is being read from a file and potentially could have values outside of the range of the arrays it is used to index into. To avoid any potential array index underflow or overflow accesses perform some sanity checking.