### PR TITLE
common: fix timeout option, break out of loop

### DIFF
--- a/common/disp.c
+++ b/common/disp.c
@@ -514,7 +514,7 @@ disp_handler(void *arg __attribute__((unused)))
 			g_run_secs = TIME_NSEC_MAX;
 			debug_print(NULL, 2,
 			    "disp: it's time to exit\n");
-			continue;
+			break;
 		}
 
 		if ((status == ETIMEDOUT) && (flag == DISP_FLAG_NONE)) {


### PR DESCRIPTION
Currently the timeout -t option does not work, the code display loop continues forever when the timeout occurs. Fix this by replacing the continue statement with a break to exit the loop.

Fixes: https://github.com/intel/numatop/issues/27