### PR TITLE
powerpc/util: fix build warning, cast LHS of expression to size_t

### DIFF
--- a/powerpc/util.c
+++ b/powerpc/util.c
@@ -88,7 +88,7 @@ arch__cpuinfo_freq(double *freq, char *unit)
 		}
 
 		c = strchr(line, ':');
-		if (c - line + 2 < len &&
+		if ((size_t)(c - line + 2) < len &&
 		    !strncmp(c + 2, "pSeries", sizeof ("pSeries") - 1)) {
 			ret = 0;
 			break;


### PR DESCRIPTION
The powerpc builds are throwing a warning, fix this with a cast.

Fixes warning:
powerpc/util.c:91:34: warning: comparison of integer expressions of different signedness: 'long int' and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
   91 |                 if (c - line + 2 < len && ...