### PR TITLE
Use dynamic allocation for node and CPU info arrays

### DIFF
--- a/common/include/os/node.h
+++ b/common/include/os/node.h
@@ -90,7 +90,7 @@ typedef struct _node_imc {
 typedef struct _node {
 	int nid;
 	int ncpus;
-	perf_cpu_t cpus[NCPUS_NODE_MAX];
+	perf_cpu_t *cpus;
 	count_value_t countval;
 	node_meminfo_t meminfo;
 	node_qpi_t qpi;

--- a/common/include/os/node.h
+++ b/common/include/os/node.h
@@ -101,7 +101,7 @@ typedef struct _node {
 
 typedef struct _node_group {
 	pthread_mutex_t mutex;
-	node_t nodes[NNODES_MAX];
+	node_t *nodes;
 	int nnodes;
 	int cpuid_max;
 	int intval_ms;

--- a/common/include/types.h
+++ b/common/include/types.h
@@ -115,7 +115,6 @@ typedef enum {
 
 #define UI_COUNT_NUM		5
 
-#define NCPUS_NODE_MAX		256
 #define NPROCS_NAX		4096
 #define	LL_THRESH		128
 #define LL_PERIOD		1000

--- a/common/include/types.h
+++ b/common/include/types.h
@@ -116,12 +116,12 @@ typedef enum {
 #define UI_COUNT_NUM		5
 
 #define NCPUS_NODE_MAX		256
-#define	NCPUS_MAX		(nnodes_max * NCPUS_NODE_MAX)
 #define NPROCS_NAX		4096
 #define	LL_THRESH		128
 #define LL_PERIOD		1000
 
 extern int nnodes_max;
+extern int ncpus_max;
 
 typedef struct _count_value {
 	uint64_t counts[PERF_COUNT_NUM];

--- a/common/include/types.h
+++ b/common/include/types.h
@@ -115,7 +115,6 @@ typedef enum {
 
 #define UI_COUNT_NUM		5
 
-#define NPROCS_NAX		4096
 #define	LL_THRESH		128
 #define LL_PERIOD		1000
 

--- a/common/include/types.h
+++ b/common/include/types.h
@@ -115,12 +115,13 @@ typedef enum {
 
 #define UI_COUNT_NUM		5
 
-#define	NNODES_MAX		64
 #define NCPUS_NODE_MAX		256
-#define	NCPUS_MAX		(NNODES_MAX * NCPUS_NODE_MAX)
+#define	NCPUS_MAX		(nnodes_max * NCPUS_NODE_MAX)
 #define NPROCS_NAX		4096
 #define	LL_THRESH		128
 #define LL_PERIOD		1000
+
+extern int nnodes_max;
 
 typedef struct _count_value {
 	uint64_t counts[PERF_COUNT_NUM];

--- a/common/numatop.c
+++ b/common/numatop.c
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
 	if (node_group_init() != 0) {
 		stderr_print("The node/cpu number is out of range, \n"
 		    "numatop supports up to %d nodes and %d CPUs\n",
-		    NNODES_MAX, NCPUS_MAX);
+		    nnodes_max, NCPUS_MAX);
 		goto L_EXIT5;
 	}
 

--- a/common/numatop.c
+++ b/common/numatop.c
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
 	if (node_group_init() != 0) {
 		stderr_print("The node/cpu number is out of range, \n"
 		    "numatop supports up to %d nodes and %d CPUs\n",
-		    nnodes_max, NCPUS_MAX);
+		    nnodes_max, ncpus_max);
 		goto L_EXIT5;
 	}
 

--- a/common/os/node.c
+++ b/common/os/node.c
@@ -167,7 +167,7 @@ cpu_refresh(boolean_t init)
 			if (!os_sysfs_cpu_enum(node->nid, cpu_arr, NCPUS_NODE_MAX, &num)) {
 				return (-1);
 			}
-			if (num < 0 || num >= NCPUS_NODE_MAX) {
+			if (num < 0 || num > NCPUS_NODE_MAX) {
 				return (-1);
 			}
 

--- a/common/os/node.c
+++ b/common/os/node.c
@@ -228,7 +228,7 @@ node_group_refresh(boolean_t init)
 	if (!os_sysfs_node_enum(node_arr, NNODES_MAX, &num)) {
 		goto L_EXIT;
 	}
-	if (num < 0 || num >= NNODES_MAX) {
+	if (num < 0 || num > NNODES_MAX) {
 		goto L_EXIT;
 	}
 

--- a/common/os/node.c
+++ b/common/os/node.c
@@ -48,6 +48,7 @@ static node_group_t s_node_group;
 int g_ncpus;
 
 int nnodes_max;
+int ncpus_max;
 
 static void
 node_init(node_t *node, int nid, boolean_t hotadd)
@@ -86,6 +87,7 @@ node_group_init(void)
 		return (-1);
 
 	nnodes_max = numa_num_possible_nodes();
+	ncpus_max = numa_num_possible_cpus();
 
 	(void) memset(&s_node_group, 0, sizeof (node_group_t));
 	if (pthread_mutex_init(&s_node_group.mutex, NULL) != 0) {

--- a/common/os/os_perf.c
+++ b/common/os/os_perf.c
@@ -1025,7 +1025,7 @@ uncore_stop_all(void)
 	node_t *node;
 	int i;
 
-	for (i = 0; i < NNODES_MAX; i++) {
+	for (i = 0; i < nnodes_max; i++) {
 		node = node_get(i);
 		if (NODE_VALID(node)) {
 			if (node->qpi.qpi_num > 0)
@@ -1455,7 +1455,7 @@ int os_uncore_stop(perf_ctl_t *ctl __attribute__((unused)),
 				pf_uncoreimc_free(node);
 		}
 	} else {
-		for (i = 0; i < NNODES_MAX; i++) {
+		for (i = 0; i < nnodes_max; i++) {
 			node = node_get(i);
 			if (NODE_VALID(node)) {
 				if (node->qpi.qpi_num > 0)

--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -470,19 +470,23 @@ os_sysfs_cpu_enum(int nid, int *cpu_arr, int arr_size, int *num)
 int
 os_sysfs_online_ncpus(void)
 {
-	int cpu_arr[NCPUS_MAX], num;
+	int *cpu_arr, num, ret = -1;
 	char path[PATH_MAX];
 
-	if (sysconf(_SC_NPROCESSORS_CONF) > NCPUS_MAX) {
+	cpu_arr = (int *) malloc(ncpus_max * sizeof(int));
+	if (!cpu_arr)
 		return (-1);
-	}
 
 	snprintf(path, PATH_MAX, "/sys/devices/system/cpu/online");
-	if (!file_int_extract(path, cpu_arr, NCPUS_MAX, &num)) {
-		return (-1);
+	if (!file_int_extract(path, cpu_arr, ncpus_max, &num)) {
+		goto L_EXIT;
 	}
 
-	return (num);
+	ret = num;
+
+L_EXIT:
+	free(cpu_arr);
+	return (ret);
 }
 
 static boolean_t

--- a/common/os/os_util.c
+++ b/common/os/os_util.c
@@ -863,7 +863,7 @@ static uint64_t cmt_field_value(char *dir, const char *field, int nid)
 	int i;
 
 	if (nid == -1) {
-		for (i = 0; i < NNODES_MAX; i++) {
+		for (i = 0; i < nnodes_max; i++) {
 			if (cmt_task_node_value(dir, i, field,
 				&tmp) == 0)
 				val += tmp;

--- a/common/os/os_win.c
+++ b/common/os/os_win.c
@@ -152,7 +152,7 @@ node_cpu_string(node_t *node, char *s1, int size)
 	}
 
 	j = 0;
-	for (i = 0; (i < NCPUS_NODE_MAX) && (j < ncpus); i++) {
+	for (i = 0; (i < ncpus_max) && (j < ncpus); i++) {
 		if ((cpus[i].cpuid != INVALID_CPUID) && (!cpus[i].hotremove)) {
 			cpuid_arr[j++] = cpus[i].cpuid;
 		}


### PR DESCRIPTION
As processor core counts increase, a known issue with using static arrays for node and CPU information is that the sizes need to be increased from time-to-time as seen in commits a3349d5 ("Increase NCPUS_NODE_MAX to 128") and 6f6cc3b ("common: Increase count of possible CPUs per-node"). This series aims to allocate these arrays at runtime based on OS-defined limits discovered through `libnuma` helpers for determining the maximum possible number of nodes and CPUs in a system.