### PR TITLE
Avoid deadlock on quitting

### DIFF
--- a/common/disp.c
+++ b/common/disp.c
@@ -640,6 +640,7 @@ L_EXIT:
 	perf_fini();
 
 	debug_print(NULL, 2, "disp thread is exiting\n");
+	s_disp_ctl.flag = DISP_FLAG_NONE;
 	return (NULL);
 }
 


### PR DESCRIPTION
by resetting the display command mailbox when the display thread exits.

Originally introduced with 8dfa30ea0311

Fixes #98